### PR TITLE
archive: support copying directories

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -340,6 +340,8 @@ func copyExtras(w *tar.Writer, extra map[string]string) error {
 			if err != nil {
 				return err
 			}
+
+			return nil
 		}
 
 		if err := copyExtraFile(w, entry, path); err != nil {
@@ -354,11 +356,6 @@ func copyExtraDir(w *tar.Writer, prefix string, entry string) filepath.WalkFunc 
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
-		}
-
-		// If this path is the root directory itself, ignore
-		if path == prefix {
-			return nil
 		}
 
 		// Get the path relative to our prefix

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -151,6 +151,31 @@ func TestArchive_dirExtra(t *testing.T) {
 	}
 }
 
+func TestArchive_dirExtraDir(t *testing.T) {
+	opts := &ArchiveOpts{
+		Extra: map[string]string{
+			"foo": filepath.Join(testFixture("archive-subdir"), "subdir"),
+		},
+	}
+
+	r, err := CreateArchive(testFixture("archive-flat"), opts)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := []string{
+		"baz.txt",
+		"foo.txt",
+		"foo/",
+		"foo/hello.txt",
+	}
+
+	entries := testArchive(t, r)
+	if !reflect.DeepEqual(entries, expected) {
+		t.Fatalf("bad: %#v", entries)
+	}
+}
+
 func TestArchive_dirNoVCS(t *testing.T) {
 	r, err := CreateArchive(testFixture("archive-flat"), new(ArchiveOpts))
 	if err != nil {


### PR DESCRIPTION
This adds support for the `Extra` field to copy extra directories into the archive. Previously, it was a mapping a files to files. We need this support in Terraform.