### PR TITLE
Add a DefaultHeader to the atlas.Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.4
+  - 1.6
 
 branches:
   only:

--- a/v1/atlas_test.go
+++ b/v1/atlas_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -21,6 +22,13 @@ type atlasServer struct {
 	t      *testing.T
 	ln     net.Listener
 	server http.Server
+}
+
+type clientTestResp struct {
+	RawPath string
+	Host    string
+	Header  http.Header
+	Body    string
 }
 
 func newTestAtlasServer(t *testing.T) *atlasServer {
@@ -78,6 +86,34 @@ func (hs *atlasServer) setupRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/v1/terraform/configurations/hashicorp/existing/versions/latest", hs.tfConfigLatest)
 	mux.HandleFunc("/api/v1/terraform/configurations/hashicorp/existing/versions", hs.tfConfigUpload)
+
+	// add an endpoint for testing arbitrary requests
+	mux.HandleFunc("/_test", hs.testHandler)
+}
+
+// testHandler echos the data sent from the client in a json object
+func (hs *atlasServer) testHandler(w http.ResponseWriter, r *http.Request) {
+
+	req := &clientTestResp{
+		RawPath: r.URL.RawPath,
+		Host:    r.Host,
+		Header:  r.Header,
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		// log this, since an error should fail the test anyway
+		hs.t.Log("error reading body:", err)
+	}
+
+	req.Body = string(body)
+
+	js, _ := json.Marshal(req)
+	if err != nil {
+		hs.t.Log("error marshaling req:", err)
+	}
+
+	w.Write(js)
 }
 
 func (hs *atlasServer) statusHandler(w http.ResponseWriter, r *http.Request) {

--- a/v1/atlas_test.go
+++ b/v1/atlas_test.go
@@ -21,7 +21,7 @@ type atlasServer struct {
 
 	t      *testing.T
 	ln     net.Listener
-	server http.Server
+	server *http.Server
 }
 
 type clientTestResp struct {
@@ -48,7 +48,8 @@ func newTestAtlasServer(t *testing.T) *atlasServer {
 	mux := http.NewServeMux()
 	hs.setupRoutes(mux)
 
-	var server http.Server
+	// TODO: this should be using httptest.Server
+	server := &http.Server{}
 	server.Handler = mux
 	hs.server = server
 	go server.Serve(ln)

--- a/v1/client.go
+++ b/v1/client.go
@@ -70,6 +70,10 @@ type Client struct {
 
 	// HTTPClient is the underlying http client with which to make requests.
 	HTTPClient *http.Client
+
+	// DefaultHeaders is a set of headers that will be added to every request.
+	// This minimally includes the atlas user-agent string.
+	DefaultHeader http.Header
 }
 
 // DefaultClient returns a client that connects to the Atlas API.
@@ -108,9 +112,12 @@ func NewClient(urlString string) (*Client, error) {
 	}
 
 	client := &Client{
-		URL:   parsedURL,
-		Token: token,
+		URL:           parsedURL,
+		Token:         token,
+		DefaultHeader: make(http.Header),
 	}
+
+	client.DefaultHeader.Set("User-Agent", userAgent)
 
 	if err := client.init(); err != nil {
 		return nil, err
@@ -227,10 +234,12 @@ func (c *Client) rawRequest(verb string, u *url.URL, ro *RequestOptions) (*http.
 		return nil, err
 	}
 
-	// Set the User-Agent
-	request.Header.Set("User-Agent", userAgent)
+	// set our default headers first
+	for k, v := range c.DefaultHeader {
+		request.Header[k] = v
+	}
 
-	// Add any headers (auth will be here if set)
+	// Add any request headers (auth will be here if set)
 	for k, v := range ro.Headers {
 		request.Header.Add(k, v)
 	}


### PR DESCRIPTION
This will give us a place to insert headers required for every request.
The first use case is that Terraform may want to add extra version
headers, but we don't want to change the signature of the client
Terraform methods.