### PR TITLE
archive: ability to create empty directories in Extra

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -50,6 +50,12 @@ func (o *ArchiveOpts) IsSet() bool {
 	return len(o.Exclude) > 0 || len(o.Include) > 0 || o.VCS
 }
 
+// Constants related to setting special values for Extra in ArchiveOpts.
+const (
+	// ExtraEntryDir just creates the Extra key as a directory entry.
+	ExtraEntryDir string = ""
+)
+
 // CreateArchive takes the given path and ArchiveOpts and archives it.
 //
 // The archive will be fully completed and put into a temporary file.
@@ -419,7 +425,29 @@ func copyConcreteEntry(
 }
 
 func copyExtras(w *tar.Writer, extra map[string]string) error {
+	var tmpDir string
+	defer func() {
+		if tmpDir != "" {
+			os.RemoveAll(tmpDir)
+		}
+	}()
+
 	for entry, path := range extra {
+		// If the path is empty, then we set it to a generic empty directory
+		if path == "" {
+			// If tmpDir is still empty, then we create an empty dir
+			if tmpDir == "" {
+				td, err := ioutil.TempDir("", "archive")
+				if err != nil {
+					return err
+				}
+
+				tmpDir = td
+			}
+
+			path = tmpDir
+		}
+
 		info, err := os.Stat(path)
 		if err != nil {
 			return err

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -53,7 +53,7 @@ func (o *ArchiveOpts) IsSet() bool {
 // Constants related to setting special values for Extra in ArchiveOpts.
 const (
 	// ExtraEntryDir just creates the Extra key as a directory entry.
-	ExtraEntryDir string = ""
+	ExtraEntryDir = ""
 )
 
 // CreateArchive takes the given path and ArchiveOpts and archives it.

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -177,6 +177,30 @@ func TestArchive_dirExtraDir(t *testing.T) {
 	}
 }
 
+func TestArchive_dirExtraDirHeader(t *testing.T) {
+	opts := &ArchiveOpts{
+		Extra: map[string]string{
+			"foo": ExtraEntryDir,
+		},
+	}
+
+	r, err := CreateArchive(testFixture("archive-flat"), opts)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := []string{
+		"baz.txt",
+		"foo.txt",
+		"foo/",
+	}
+
+	entries := testArchive(t, r, false)
+	if !reflect.DeepEqual(entries, expected) {
+		t.Fatalf("bad: %#v", entries)
+	}
+}
+
 func TestArchive_dirMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("modes don't work on Windows")


### PR DESCRIPTION
This adds a special key (currently just empty string, but using the constant is recommended) to just create an empty directory entry within the `Extra` field. This is useful to make sure the proper parent hierarchy is created when inserting an extra field in some nested location.

I originally wanted to automatically do this but unfortunately there is no way to know if a tar already contains the directory entries short of storing them all in memory which I didn't want to do. We can look at that again in the future if we wanted but this feature wouldn't preclude that from happening.