### PR TITLE
Added ATLAS_TLS_NOVERIFY env option

### DIFF
--- a/v1/client.go
+++ b/v1/client.go
@@ -34,6 +34,11 @@ const (
 	// load trusted certs from a directory
 	atlasCAPathEnvVar = "ATLAS_CAPATH"
 
+	// atlasTLSNoVerifyEnvVar disables TLS verification, similar to curl -k
+	// This defaults to false (verify) and will change to true (skip
+	// verification) with any non-empty value
+	atlasTLSNoVerifyEnvVar = "ATLAS_TLS_NOVERIFY"
+
 	// atlasTokenHeader is the header key used for authenticating with Atlas
 	atlasTokenHeader = "X-Atlas-Token"
 )
@@ -130,6 +135,9 @@ func NewClient(urlString string) (*Client, error) {
 func (c *Client) init() error {
 	c.HTTPClient = cleanhttp.DefaultClient()
 	tlsConfig := &tls.Config{}
+	if os.Getenv(atlasTLSNoVerifyEnvVar) != "" {
+		tlsConfig.InsecureSkipVerify = true
+	}
 	err := rootcerts.ConfigureTLS(tlsConfig, &rootcerts.Config{
 		CAFile: os.Getenv(atlasCAFileEnvVar),
 		CAPath: os.Getenv(atlasCAPathEnvVar),

--- a/v1/client_test.go
+++ b/v1/client_test.go
@@ -1,6 +1,7 @@
 package atlas
 
 import (
+	"net/http"
 	"net/url"
 	"os"
 	"reflect"
@@ -58,6 +59,30 @@ func TestNewClient_parsesURL(t *testing.T) {
 	if !reflect.DeepEqual(client.URL, expected) {
 		t.Fatalf("expected %q to equal %q", client.URL, expected)
 	}
+}
+
+func TestNewClient_TLSVerify(t *testing.T) {
+	client, err := NewClient("https://example.com/foo/bar")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify != false {
+		t.Fatal("Expected InsecureSkipVerify to be false")
+	}
+}
+
+func TestNewClient_TLSNoVerify(t *testing.T) {
+	os.Setenv("ATLAS_TLS_NOVERIFY", "1")
+	client, err := NewClient("https://example.com/foo/bar")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify != true {
+		t.Fatal("Expected InsecureSkipVerify to be true when ATLAS_TLS_NOVERIFY is set")
+	}
+	os.Setenv("ATLAS_TLS_NOVERIFY", "")
 }
 
 func TestNewClient_setsDefaultHTTPClient(t *testing.T) {


### PR DESCRIPTION
Set to a non-empty value to skip TLS cert verification, similar to `curl -k`.

/cc @grubernaut @sean- @phinze