### PR TITLE
send a list of key/value pairs as vars

### DIFF
--- a/v1/build_config.go
+++ b/v1/build_config.go
@@ -187,6 +187,6 @@ type bcCreateWrapper struct {
 	Version struct {
 		Metadata map[string]interface{} `json:"metadata,omitempty"`
 		Builds   []BuildConfigBuild     `json:"builds"`
-		Vars     BuildVars              `json:"vars,omitempty"`
+		Vars     BuildVars              `json:"packer_vars,omitempty"`
 	} `json:"version"`
 }

--- a/v1/build_config.go
+++ b/v1/build_config.go
@@ -13,6 +13,10 @@ type bcWrapper struct {
 	BuildConfig *BuildConfig `json:"build_configuration"`
 }
 
+// Atlas expects a list of key/value vars
+type BuildVar map[string]string
+type BuildVars []BuildVar
+
 // BuildConfig represents a Packer build configuration.
 type BuildConfig struct {
 	// User is the namespace under which the build config lives
@@ -126,7 +130,7 @@ func (c *Client) CreateBuildConfig(user, name string) (*BuildConfig, error) {
 //
 // Actual API: "Create Build Config Version"
 func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[string]interface{},
-	vars map[string]string, data io.Reader, size int64) error {
+	vars BuildVar, data io.Reader, size int64) error {
 
 	log.Printf("[INFO] uploading build configuration version %s (%d bytes), with metadata %q",
 		v.Slug(), size, metadata)
@@ -137,7 +141,7 @@ func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[st
 	var bodyData bcCreateWrapper
 	bodyData.Version.Builds = v.Builds
 	bodyData.Version.Metadata = metadata
-	bodyData.Version.Vars = vars
+	bodyData.Version.Vars = BuildVars{vars}
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return err
@@ -180,6 +184,6 @@ type bcCreateWrapper struct {
 	Version struct {
 		Metadata map[string]interface{} `json:"metadata,omitempty"`
 		Builds   []BuildConfigBuild     `json:"builds"`
-		Vars     map[string]string      `json:"vars,omitempty"`
+		Vars     BuildVars              `json:"vars,omitempty"`
 	} `json:"version"`
 }

--- a/v1/build_config.go
+++ b/v1/build_config.go
@@ -14,7 +14,10 @@ type bcWrapper struct {
 }
 
 // Atlas expects a list of key/value vars
-type BuildVar map[string]string
+type BuildVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
 type BuildVars []BuildVar
 
 // BuildConfig represents a Packer build configuration.
@@ -130,7 +133,7 @@ func (c *Client) CreateBuildConfig(user, name string) (*BuildConfig, error) {
 //
 // Actual API: "Create Build Config Version"
 func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[string]interface{},
-	vars BuildVar, data io.Reader, size int64) error {
+	vars BuildVars, data io.Reader, size int64) error {
 
 	log.Printf("[INFO] uploading build configuration version %s (%d bytes), with metadata %q",
 		v.Slug(), size, metadata)
@@ -141,7 +144,7 @@ func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[st
 	var bodyData bcCreateWrapper
 	bodyData.Version.Builds = v.Builds
 	bodyData.Version.Metadata = metadata
-	bodyData.Version.Vars = BuildVars{vars}
+	bodyData.Version.Vars = vars
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return err

--- a/v1/build_config_test.go
+++ b/v1/build_config_test.go
@@ -87,7 +87,7 @@ func TestUploadBuildConfigVersion(t *testing.T) {
 		},
 	}
 	metadata := map[string]interface{}{"testing": true}
-	vars := map[string]string{"one": "two"}
+	vars := BuildVars{BuildVar{Key: "one", Value: "two"}}
 	data := new(bytes.Buffer)
 	err = client.UploadBuildConfigVersion(bc, metadata, vars, data, int64(data.Len()))
 	if err != nil {


### PR DESCRIPTION
This should bring us more in line with how TF works. That way we don't have to support multiple var formats and will future proof us for if/when packer moves to HCL