### PR TITLE
Perform a pre-flight HEAD request during putFile.

### DIFF
--- a/v1/atlas_test.go
+++ b/v1/atlas_test.go
@@ -481,10 +481,10 @@ func (hs *atlasServer) vagrantUploadAppHandler(w http.ResponseWriter, r *http.Re
 }
 
 func (hs *atlasServer) binstoreHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "PUT" {
+	switch r.Method {
+	case "PUT", "HEAD":
+		w.WriteHeader(http.StatusOK)
+	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 }

--- a/v1/client.go
+++ b/v1/client.go
@@ -194,7 +194,7 @@ func (c *Client) Request(verb, spath string, ro *RequestOptions) (*http.Request,
 func (c *Client) putFile(rawURL string, r io.Reader, size int64) error {
 	log.Printf("[INFO] sending pre-flight request: %s", rawURL)
 
-	resp, err := c.HTTPClient.Head(rawURL)
+	resp, err := checkResp(c.HTTPClient.Head(rawURL))
 	if err != nil {
 		return err
 	}

--- a/v1/client.go
+++ b/v1/client.go
@@ -192,6 +192,18 @@ func (c *Client) Request(verb, spath string, ro *RequestOptions) (*http.Request,
 }
 
 func (c *Client) putFile(rawURL string, r io.Reader, size int64) error {
+	log.Printf("[INFO] sending pre-flight request: %s", rawURL)
+
+	resp, err := c.HTTPClient.Head(rawURL)
+	if err != nil {
+		return err
+	}
+
+	if v := resp.Header.Get("Location"); v != "" {
+		log.Printf("[INFO] got redirect location: %s", v)
+		rawURL = v
+	}
+
 	log.Printf("[INFO] putting file: %s", rawURL)
 
 	url, err := url.Parse(rawURL)


### PR DESCRIPTION
Adds a pre-flight (HEAD) request prior to attempting to upload. This is a more simple way of accomplishing what #60 is doing and is easier to reason about.