### PR TITLE
add sensitive to api

### DIFF
--- a/v1/build_config.go
+++ b/v1/build_config.go
@@ -15,8 +15,9 @@ type bcWrapper struct {
 
 // Atlas expects a list of key/value vars
 type BuildVar struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	Sensitive bool   `json:"sensitive"`
 }
 type BuildVars []BuildVar
 


### PR DESCRIPTION
Adding sensitive option to the api for packer push.  See issue here: https://github.com/hashicorp/packer/issues/4727

and this PR on the terraform side:
https://github.com/hashicorp/atlas/commit/d5d1f341eaff2d6b924fb528c05dcdb205b4b326