### PR TITLE
increase test timeout to 10s, bump to go >= 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: go
 
 go:
-  - 1.6
+  - 1.7
+  - 1.8
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build -o bin/atlas-go ./v1
 
 test:
-	go test $(TEST) $(TESTARGS) -timeout=3s -parallel=4
+	go test $(TEST) $(TESTARGS) -timeout=10s -parallel=4
 	go vet $(TEST)
 	go test $(TEST) -race
 


### PR DESCRIPTION
the tests fail for me unless I increase the timeout

```
go test ./...  -timeout=10s -parallel=4
ok  	github.com/hashicorp/atlas-go/archive	0.257s
ok  	github.com/hashicorp/atlas-go/v1	3.646s
go vet ./...
go test ./... -race
ok  	github.com/hashicorp/atlas-go/archive	1.436s
ok  	github.com/hashicorp/atlas-go/v1	7.429s
```

go-cleanhttp also introduced a [dependency on go 1.7](https://golang.org/doc/go1.7#net_http), so make our tests run on 1.7 and 1.8.