### PR TITLE
don't copy symlink target twice; instead, return first time you copy …

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -372,6 +372,8 @@ func copyDirWalkFn(
 				return filepath.Walk(target, copyDirWalkFn(
 					tarW, target, subpath, opts, vcsInclude))
 			}
+			// return now so that we don't try to copy twice
+			return nil
 		}
 
 		return copyConcreteEntry(tarW, subpath, path, info)


### PR DESCRIPTION
…the symlink

The code here follows the link path and then copies the target, naming it for the link.  Before, it would do this and then continue to try the copy again, this time using the fileinfo for the symlink. 
 
The archive write was failing on symlinks because it'd generate a header saying the link had a size of zero, then try to copy the target.  

As it's written now, this will flatten the symlinks.  So if I have a link named "linkylink" pointing at a file named "fileyfile", then when this is done we'll have a file named "linkylink" containing the info that fileyfile used to contain.

solves https://github.com/hashicorp/packer/issues/5160